### PR TITLE
Update database class to use promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js: "4.3.1"
 script: "npm run travis"
+services: mongodb
+before_script:
+  - sleep 15

--- a/database.js
+++ b/database.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const MongoClient = require('mongodb')
 
 class Database {
@@ -7,18 +5,44 @@ class Database {
   constructor (uri) {
     this.uri = uri
     this.db = {}
-    MongoClient.connect(uri, (err, db) => {
-      if (err) return console.log(err)
-      this.db = db
+    return this
+  }
+
+  connect () {
+    return new Promise((resolve, reject) => {
+      MongoClient.connect(this.uri, (err, db) => {
+        if (err) return reject(err)
+        this.db = db
+        resolve(this)
+      })
     })
   }
 
-  addReport (domain, cb) {
-    this.db.collection('domains').findAndModify({ domain: domain }, {}, { $inc: { reported: 1 } }, { new: true , upsert: true }, cb)
+  addReport (domain) {
+    return new Promise((resolve, reject) => {
+      this.db.collection('domains').findAndModify(
+        { domain: domain }
+      , {}
+      , { $inc: { reported: 1 } }
+      , { new: true, upsert: true }
+      , (err, data) => {
+          if (err) return reject(err)
+          resolve(data)
+        })
+    })
+
   }
 
-  findReport (domain, cb) {
-    this.db.collection('domains').findOne({ domain: domain }, { _id: false, reported: true }, cb)
+  findReport (domain) {
+    return new Promise((resolve, reject) => {
+      this.db.collection('domains').findOne(
+        { domain: domain }
+      , { _id: false, reported: true }
+      , (err, data) => {
+          if (err) return reject(err)
+          resolve(data)
+        })
+    })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "build": "npm run clean && npm run build-css && npm run build-js",
     "watch": "npm run clean && npm run watch-css & npm run watch-js & nodemon -e js,jade",
     "start": "node server",
-    "test": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha && rm -rf coverage/",
-    "travis": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover ./node_modules/.bin/_mocha -- -R spec  && ./node_modules/.bin/codecov"
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/.bin/mocha -- --compilers js:babel-register && rm -rf coverage/",
+    "travis": "./node_modules/.bin/istanbul cover ./node_modules/.bin/mocha -- -R spec --compilers js:babel-register  && ./node_modules/.bin/codecov"
   },
   "author": "aardvarks",
   "engines": {
@@ -33,11 +33,10 @@
     "stylus": "^0.54.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.8.0",
     "babel-core": "^6.7.7",
-    "babel-istanbul": "^0.8.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.8.0",
     "codecov": "^1.0.1",
     "eslint": "^2.1.0",
     "eslint-config-clock": "^1.0.2",

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1,33 +1,35 @@
 'use strict'
 
 var Database = require('../database')
-  , database = new Database('mongodb://localhost:27017/test')
+  , dbUrl = 'mongodb://localhost:27017/test'
   , assert = require('assert')
 
 describe('Database', () => {
+  let database
 
-  after(() => {
+  beforeEach((done) => {
+    database = new Database(dbUrl)
+    database.connect()
+      .then(() => { done() })
+      .catch((err) => { done(err) })
+  })
+
+  afterEach(() => {
     database.db.dropDatabase()
   })
 
   it('should add a domain to the database with one report', (done) => {
-    setTimeout(() => {
-      database.addReport('google.com', (err, data) => {
-       assert.equal(err, null, 'domain not inserted')
-       assert.equal(data.value.domain, 'google.com', 'domain not inserted')
+    database.addReport('google.com')
+      .then((data) => {
+        assert.equal(data.value.domain, 'google.com', 'domain not inserted')
       })
-
-      database.findReport('google.com', (err, data) => {
-        assert.equal(err, null, 'failed to get result')
+      .then(database.findReport.bind(database, 'google.com'))
+      .then((data) => {
         assert.equal(data.reported, 1, 'incorrect number of reports')
         done()
       })
-    }, 100)
+      .catch((err) => {
+        done(err)
+      })
   })
 })
-
-
-
-
-
-


### PR DESCRIPTION
Also fix the tests as now no timeout is needed.
Test scripts were changed from using `babel-node` and `babel-istanbul` to use `babel-register`, so that es6 can be used properly in mocha tests.

I'm pretty sure there's a way around having to do this - https://git.io/vwhOS - but I can't for the life of me remember what it is.
